### PR TITLE
conda envs from GMBSR_refs

### DIFF
--- a/job.script.sh
+++ b/job.script.sh
@@ -7,22 +7,22 @@
 #SBATCH --nodes=1
 
 # specify que to submit to (preempt1 only contains q10 DAC node)
-#SBATCH --partition=preempt1
+#SBATCH --partition=standard
 
 # specify account you are submitting from
-#SBATCH --account=dac
+#SBATCH --account=nccc
 
 # Walltime (job duration)
 #SBATCH --time=60:00:00
 
 # Email address
-#SBATCH --mail-user=omw@dartmouth.edu
+#SBATCH --mail-user=XXXXXXXXX@dartmouth.edu
 
 # Email notifications (comma-separated options: BEGIN,END,FAIL)
 #SBATCH --mail-type=FAIL
 
 source /optnfs/common/miniconda3/etc/profile.d/conda.sh
-conda activate /dartfs-hpc/rc/lab/G/GMBSR_bioinfo/misc/sullivan/tools/snakemake/snakemake-7.18
-snakemake -s Snakefile  --conda-frontend conda --use-conda --conda-prefix /dartfs-hpc/rc/lab/G/GMBSR_bioinfo/misc/sullivan/tools/pipeline_envs/rnaseq \
+conda activate /dartfs/rc/nosnapshots/G/GMBSR_refs/envs/snakemake
+snakemake -s Snakefile  --conda-frontend conda --use-conda --conda-prefix /dartfs/rc/nosnapshots/G/GMBSR_refs/envs/DAC-RNAseq-pipeline \
 	--profile cluster_profile \
 	--rerun-incomplete --keep-going


### PR DESCRIPTION
Changed conda envs so they point to the GMBSR_refs directory replaced Owens email address with XXXXX
replaced preempt1 partition with standard which most people at Dartmouth would have access to replaced account with nccc which more people will have access to than dac