### PR TITLE
Update config.yaml

### DIFF
--- a/cluster_profile/config.yaml
+++ b/cluster_profile/config.yaml
@@ -1,5 +1,6 @@
 jobs: 10
-cluster: "sbatch -t {resources.maxtime} --mem={resources.mem_mb} -c {resources.cpus} --mail-type=FAIL --mail-user=omw@dartmouth.edu"
+jobname: "{rule}.{jobid}"
+cluster: "sbatch -t {resources.maxtime} --mem={resources.mem_mb} -c {resources.cpus} --mail-type=FAIL"
 default-resources: [cpus=1, time_min=60]
 max-jobs-per-second: 5
 max-status-checks-per-second: 20


### PR DESCRIPTION
removed the slurm option for specifying an email address. In the manual for sbatch it states that if this is not specified the default is the submitting user, which I think is a better option. 

From the manual

--mail-user=<user>
User to receive email notification of state changes as defined by --mail-type. This may be a full email address or a username. If a username is specified, the value from MailDomain in slurm.conf will be appended to create an email address. The default value is the submitting user.